### PR TITLE
Add support for NOTIFY message

### DIFF
--- a/src/SIPSTERAccount.cc
+++ b/src/SIPSTERAccount.cc
@@ -64,20 +64,6 @@ AccountConfig SIPSTERAccount::genConfig(Local<Object> acct_obj) {
 
     acct_cfg.regConfig = regConfig;
   }
-  val = acct_obj->Get(Nan::New("mwiConfig").ToLocalChecked());
-  if (val->IsObject()) {
-    AccountMwiConfig mwiConfig;
-    Local<Object> mwi_obj = val->ToObject();
-
-    val = mwi_obj->Get(Nan::New("enabled").ToLocalChecked());
-    if (val->IsBoolean()) {
-      mwiConfig.enabled = val->BooleanValue();
-    }
-
-    JS2PJ_UINT(mwi_obj, expirationSec, mwiConfig);
-
-    acct_cfg.mwiConfig = mwiConfig;
-  }
   val = acct_obj->Get(Nan::New("sipConfig").ToLocalChecked());
   if (val->IsObject()) {
     AccountSipConfig sipConfig;

--- a/src/SIPSTERAccount.h
+++ b/src/SIPSTERAccount.h
@@ -24,6 +24,7 @@ public:
   virtual void onRegStarted(OnRegStartedParam &prm);
   virtual void onRegState(OnRegStateParam &prm);
   virtual void onIncomingCall(OnIncomingCallParam &iprm);
+  virtual void onMwiInfo(OnMwiInfoParam &prm);
   static NAN_METHOD(New);
   static NAN_METHOD(Modify);
   static NAN_GETTER(ValidGetter);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -14,6 +14,7 @@
   CALLDTMF_FIELDS
   REGSTATE_FIELDS
   REGSTARTING_FIELDS
+  NOTIFY_FIELDS
 #undef X
 
 #define X(kind, literal)                                                       \
@@ -349,6 +350,20 @@ void dumb_cb(uv_async_t* handle) {
            : Nan::New(ev_REGSTARTING_unregistering_symbol))
         };
         acct->emit->Call(acct->handle(), 1, emit_argv);
+        delete args;
+      }
+      break;
+      case EVENT_NOTIFY: {
+        EV_ARGS_NOTIFY* args =
+          reinterpret_cast<EV_ARGS_NOTIFY*>(ev.args);
+        SIPSTERAccount* acct = ev.acct;
+
+        Local<Value> emit_argv[3] = {
+           Nan::New(ev_NOTIFY_notify_symbol),
+           Nan::New(args->waiting),
+           Nan::New<String>(args->info).ToLocalChecked()
+        };
+        acct->emit->Call(acct->handle(), 3, emit_argv);
         delete args;
       }
       break;
@@ -816,6 +831,7 @@ extern "C" {
   CALLDTMF_FIELDS
   REGSTATE_FIELDS
   REGSTARTING_FIELDS
+  NOTIFY_FIELDS
 #undef X
 
     CALLDTMF_DTMF0_symbol.Reset(Nan::New("0").ToLocalChecked());

--- a/src/common.h
+++ b/src/common.h
@@ -75,7 +75,8 @@ using namespace pj;
   X(REGSTATE)                                                                  \
   X(CALLMEDIA)                                                                 \
   X(PLAYEREOF)                                                                 \
-  X(REGSTARTING)
+  X(REGSTARTING)                                                               \
+  X(NOTIFY)
 
 #define EVENT_SYMBOLS                                                          \
   X(INCALL, call)                                                              \
@@ -93,7 +94,8 @@ using namespace pj;
   X(CALLMEDIA, media)                                                          \
   X(PLAYEREOF, eof)                                                            \
   X(REGSTARTING, registering)                                                  \
-  X(REGSTARTING, unregistering)
+  X(REGSTARTING, unregistering)                                                \
+  X(NOTIFY, notify)
 
 enum SIPEvent {
 #define X(kind)                                                                \
@@ -169,12 +171,25 @@ struct EV_ARGS_CALLDTMF {
 #undef X
 };
 
+// NOTIFY event ====================================================
+#define N_NOTIFY_FIELDS 2
+#define NOTIFY_FIELDS                                                          \
+  X(NOTIFY, bool, waiting, Boolean, waiting)                                   \
+  X(NOTIFY, string, info, String, info.c_str())
+struct EV_ARGS_NOTIFY {
+#define X(kind, ctype, name, v8type, valconv) ctype name;
+  NOTIFY_FIELDS
+#undef X
+};
+// =============================================================================
+
 #define X(kind, ctype, name, v8type, valconv)                                  \
   extern Nan::Persistent<String> kind##_##name##_symbol;
   INCALL_FIELDS
   CALLDTMF_FIELDS
   REGSTATE_FIELDS
   REGSTARTING_FIELDS
+  NOTIFY_FIELDS
 #undef X
 
 // start generic event-related definitions =====================================


### PR DESCRIPTION
NOTIFY message provides information about voicemail
waiting. add onMwiInfo callback that can be used
to get information from NOTIFY message so that message
waiting info can be handled/displayed.
